### PR TITLE
feat: Changed the logic to detect token generation uri with parameterized content type

### DIFF
--- a/apisix/plugins/authz-keycloak.lua
+++ b/apisix/plugins/authz-keycloak.lua
@@ -768,7 +768,7 @@ function _M.access(conf, ctx)
     local headers = core.request.headers(ctx)
     local need_grant_token = conf.password_grant_token_generation_incoming_uri and
         ctx.var.request_uri == conf.password_grant_token_generation_incoming_uri and
-        headers["content-type"] == "application/x-www-form-urlencoded" and
+        sub_str(headers["content-type"], 1, 11) == "application/x-www-form-urlencoded" and
         core.request.get_method() == "POST"
     if need_grant_token then
         return generate_token_using_password_grant(conf,ctx)


### PR DESCRIPTION
### Description

In HTTP specification, the form of Content-Type as following:
Content-Type: <media-type>[; key=value]

For examples:

Content-Type: text/html; charset=utf-8
Content-Type: multipart/form-data; boundary=boundary-string

But in the authz-keycloak plugin, the condition to decide if current request is for granting token from Keycloak must be full match the "application/x-www-form-urlencoded". It will cause some client libraries to be unable to obtain the token.

For example, the RestTemplate in SpringFramework, it will add parameter after the content-type directive automatically.

This pull request resolved this issue.